### PR TITLE
raise the upload process cap to 8 and bump version to 3.0.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rda_python_dsquasar"
-version = "3.0.7"
+version = "3.0.8"
 authors = [
   { name="Zaihua Ji", email="zji@ucar.edu" },
 ]

--- a/src/rda_python_dsquasar/dsquasar.py
+++ b/src/rda_python_dsquasar/dsquasar.py
@@ -90,9 +90,9 @@ class DsQuasar(PgCMD, PgSplit):
       self.MPTMAX = 12            # maximum number of batch processes for tarring
       # uploading (BCKACT) forks one child per BCKSIZE transfer batch (~BCKSIZE/TARSIZE
       # tar files each), so far fewer parallel units than tar files: use a large
-      # per-process limit and a low cap to avoid over-reserving cpus.
+      # per-process limit to avoid over-reserving cpus.
       self.MPBLIMIT = 900         # tar file count per batch process for uploading
-      self.MPBMAX = 4             # maximum number of batch processes for uploading
+      self.MPBMAX = 8             # maximum number of batch processes for uploading
       self.MAXRUNTIME = 23*3600   # 23 hours; stop before the 24-hour PBS walltime
       self.ONEHOUR = 3600         # seconds; time headroom needed to finish before walltime
       # a repeat submit normally blocks as a duplicate while the batch job is running. if


### PR DESCRIPTION
Large upload backlogs (-A 4) were throttled at 4 batch processes; allow up to 8 so transfers scale with the number of pending tar files.