### PR TITLE
hold uploads to 4 processes past a large backlog; bump version to 3.0.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rda_python_dsquasar"
-version = "3.0.9"
+version = "3.0.10"
 authors = [
   { name="Zaihua Ji", email="zji@ucar.edu" },
 ]

--- a/src/rda_python_dsquasar/dsquasar.py
+++ b/src/rda_python_dsquasar/dsquasar.py
@@ -90,9 +90,10 @@ class DsQuasar(PgCMD, PgSplit):
       self.MPTMAX = 12            # maximum number of batch processes for tarring
       # uploading (BCKACT) forks one child per BCKSIZE transfer batch (~BCKSIZE/TARSIZE
       # tar files each), so far fewer parallel units than tar files: use a large
-      # per-process limit to avoid over-reserving cpus.
-      self.MPBLIMIT = 900         # tar file count per batch process for uploading
-      self.MPBMAX = 8             # maximum number of batch processes for uploading
+      # per-process limit to avoid over-reserving cpus. Globus runs only a few
+      # concurrent transfers, so extra upload processes just wait on it.
+      self.MPBLIMIT = 5000        # tar file count per batch process for uploading
+      self.MPBMAX = 4             # maximum number of batch processes for uploading
       self.MAXRUNTIME = 23*3600   # 23 hours; stop before the 24-hour PBS walltime
       self.ONEHOUR = 3600         # seconds; time headroom needed to finish before walltime
       # a repeat submit normally blocks as a duplicate while the batch job is running. if


### PR DESCRIPTION
Globus runs only a few concurrent transfers, so extra upload children just queue behind it.  Lower the upload process cap from 8 back to 4 and raise the per-process limit to 5000 tar files, keeping -A 4 single process until the pending status 'T' backlog passes roughly 24TB.

Tarring is unchanged: -A 3 keeps MPTLIMIT 200 and MPTMAX 12.